### PR TITLE
replaces htme-release step from get to a task

### DIFF
--- a/ci/jobs/test.yml
+++ b/ci/jobs/test.yml
@@ -1,9 +1,6 @@
 jobs:
 - name: test
   plan:
-  - get: htme-release
-    trigger: true
-    version: every
   - get: dw-al2-hardened-ami
     trigger: true
     version: every
@@ -11,6 +8,13 @@ jobs:
     trigger: true
     version: every
   - get: terraform-aws-dataworks-htme
+  - get: aws-management-infrastructure
+  - .: (( inject meta.plan.terraform-output-management ))
+  - .: (( inject meta.plan.get-artefacts ))
+    config:
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+        AWS_ACC: ((aws_account.management))
   - put: terraform-aws-dataworks-htme-test
     params:
       repository: terraform-aws-dataworks-htme

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -88,7 +88,7 @@ meta:
           - -exc
           - |
             export TF_VAR_al2_hardened_ami_id=$(cat ../dw-al2-hardened-ami/id)
-            export TF_VAR_htme_version=$(cat ../htme-release/version)
+            export TF_VAR_htme_version=$(cat ../artefacts/htme-release/version)
             cp ../terraform-config/terraform.tfvars ./example
             cp ../terraform-config/terraform.tf ./example
             go mod init htme
@@ -100,7 +100,7 @@ meta:
           - name: terraform-aws-dataworks-htme
           - name: terraform-config
           - name: dw-al2-hardened-ami
-          - name: htme-release
+          - name: artefacts
 
     notify:
       on_success:
@@ -147,3 +147,60 @@ meta:
               text: |
                 The <https://ci.dataworks.dwp.gov.uk/builds/$BUILD_ID|$BUILD_JOB_NAME> stage for <https://ci.dataworks.dwp.gov.uk/teams/dataworks/pipelines/$BUILD_PIPELINE_NAME|*$BUILD_PIPELINE_NAME*> has been aborted.
               attachment_type: "default"
+
+    terraform-output-management:
+      task: terraform-output-management
+      .: (( inject meta.plan.terraform-common-config ))
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.terraform_repository))
+            version: ((dataworks.terraform_version))
+            tag: ((dataworks.terraform_version))
+        params:
+          TF_WORKSPACE: management
+        run:
+          path: sh
+          dir: aws-management-infrastructure
+          args:
+            - -exc
+            - |
+              terraform init
+              terraform workspace show
+              terraform output --json > ../terraform-output-management/outputs.json
+        inputs:
+          - name: aws-management-infrastructure
+        outputs:
+          - name: terraform-output-management
+
+    get-artefacts:
+      task: get-artefacts
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            version: ((dataworks.docker_awscli_version))
+            tag: ((dataworks.docker_awscli_version))
+        params:
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+        inputs:
+          - name: terraform-output-management
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              export AWS_DEFAULT_REGION
+              source /assume-role
+              set +x
+              ARTEFACT_BUCKET=`cat terraform-output-management/outputs.json | jq -r ".artefact_bucket.value.id"`
+              LATEST_ARTEFACT=`aws s3 ls s3://${ARTEFACT_BUCKET}/hbase-to-mongo-export/gitlabci/ | sort | tail -n 1 | awk '{print $4}')`
+              echo $LATEST_ARTEFACT
+              aws s3 cp s3://${ARTEFACT_BUCKET}/hbase-to-mongo-export/gitlabci/$LATEST_ARTEFACT ./artefacts/htme-release/$LATEST_ARTEFACT
+              echo $(ls ./artefacts/htme-release/*.jar | sed -e 's/^.*export-//' -e 's/.jar$//') > ./artefacts/htme-release/version
+        outputs:
+          - name: artefacts

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -52,15 +52,16 @@ resources:
         name: dw-al2-hardened-ami-*
         architecture: x86_64
 
-  - name: htme-release
-    type: github-release
-    source:
-      owner: dwp
-      repository: hbase-to-mongo-export
-      access_token: ((dataworks-secrets.concourse_github_pat))
-    check_every: 10m
-
   - name: slack
     type: slack-notification
     source:
       url: ((dataworks.slack_webhook_url))
+
+  - name: aws-management-infrastructure
+    type: git
+    source:
+      branch: master
+      username: ((dataworks.enterprise_github_username))
+      password: ((dataworks-secrets.enterprise_github_pat))
+      uri: https://((dataworks.enterprise_github_url))/dip/aws-management-infrastructure.git
+    check_every: 5m

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -101,7 +101,7 @@ chmod u+x /opt/htme/htme_cloudwatch.sh
 
 echo "Download & install latest hbase-to-mongo-export service artifact"
 VERSION="${htme_version}"
-URL="s3://${s3_artefact_bucket_id}/hbase-to-mongo-export/hbase-to-mongo-export-$VERSION.jar"
+URL="s3://${s3_artefact_bucket_id}/hbase-to-mongo-export/gitlabci/hbase-to-mongo-export-$VERSION.jar"
 $(which aws) s3 cp $URL /opt/htme/htme.jar
 echo "JAR_VERSION: $VERSION"
 echo "JAR_DOWNLOAD_URL: $URL"

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -101,7 +101,7 @@ chmod u+x /opt/htme/htme_cloudwatch.sh
 
 echo "Download & install latest hbase-to-mongo-export service artifact"
 VERSION="${htme_version}"
-URL="s3://${s3_artefact_bucket_id}/hbase-to-mongo-export/gitlabci/hbase-to-mongo-export-$VERSION.jar"
+URL="s3://${s3_artefact_bucket_id}/hbase-to-mongo-export/hbase-to-mongo-export-$VERSION.jar"
 $(which aws) s3 cp $URL /opt/htme/htme.jar
 echo "JAR_VERSION: $VERSION"
 echo "JAR_DOWNLOAD_URL: $URL"


### PR DESCRIPTION
- updates concourse conf to source `htme-release` artefact from s3
- updates `userdata.tpl` to source `.jar` from updated s3 location where `gitlab` pushes the `.jar`